### PR TITLE
Ajuste del enpoint POST asignar tareas 

### DIFF
--- a/app/api/v1/endpoints/tasks.py
+++ b/app/api/v1/endpoints/tasks.py
@@ -11,7 +11,6 @@ from sqlalchemy.exc import IntegrityError
 from sqlalchemy import desc, asc
 from app.db.session import get_session
 from app.models import CategoriaTarea, TaskTag
-from app.schemas.tag import TagAssignRequest
 from app.services.auth import get_current_user
 from app.models.task import Task, TaskHistory, EstadoTarea
 from app.schemas.task import TaskCreate, TaskRead, TaskUpdate, TaskAssignmentCreate, TaskAssignmentRead
@@ -227,25 +226,3 @@ async def get_assigned_tasks(
 ):
     return await TaskAssignmentService.get_assigned_tasks(session=session, user_id=user_id)
 
-@router.post("/{task_id}/tags", status_code=200, summary="Asignar etiquetas", description="Asigna etiquetas a una tarea específica.")
-async def assign_tags_to_task(
-        task_id: UUID,
-        payload: TagAssignRequest,
-        session: AsyncSession = Depends(get_session),
-        current_user: Usuario = Depends(get_current_user)
-):
-    # Verifica que la tarea exista y pertenezca al usuario
-    task = await session.get(Task, task_id)
-    if not task or task.user_id != current_user.id:
-        raise HTTPException(status_code=404, detail="Tarea no encontrada.")
-
-    # Crear relaciones TaskTag (evitar duplicados)
-    for tag_id in payload.tag_ids:
-        result = await session.exec(
-            select(TaskTag).where(TaskTag.task_id == task_id, TaskTag.tag_id == tag_id)
-        )
-        if not result.first():
-            session.add(TaskTag(task_id=task_id, tag_id=tag_id))
-
-    await session.commit()
-    return {"message": "Etiquetas asignadas correctamente"}

--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -90,7 +90,7 @@ async def test_assign_tags_to_task(async_client: AsyncClient, session):
     tag_ids = [tag1.json()["id"], tag2.json()["id"]]
 
     # Asignar etiquetas a la tarea
-    resp = await async_client.post(f"/api/v1/tasks/{task_id}/tags", json={"tag_ids": tag_ids}, headers=headers)
+    resp = await async_client.post(f"/api/v1/tags/tasks/{task_id}/tags", json={"tag_ids": tag_ids}, headers=headers)
     assert resp.status_code == 200
     assert resp.json()["message"] == "Etiquetas asignadas correctamente"
 
@@ -120,7 +120,7 @@ async def test_delete_tag_cascade_removes_tasktag(async_client: AsyncClient, ses
 
     # Asignar la etiqueta a la tarea
     assign_resp = await async_client.post(
-        f"/api/v1/tasks/{task_id}/tags",
+        f"/api/v1/tags/tasks/{task_id}/tags",
         json={"tag_ids": [str(tag_id)]},
         headers=headers
     )

--- a/tests/test_tasks_filters.py
+++ b/tests/test_tasks_filters.py
@@ -105,7 +105,7 @@ async def test_get_tasks_filtered_by_tag(async_client: AsyncClient):
 
     # Asignar etiqueta a la tarea
     assign_resp = await async_client.post(
-        f"/api/v1/tasks/{task_id}/tags",
+        f"/api/v1/tags/tasks/{task_id}/tags",
         json={"tag_ids": [tag_id]},
         headers=headers
     )


### PR DESCRIPTION
Ajuste del enpoint POST asignar tareas a ETIQUETAS. Cambiar la direcion correcta de la url en los test_tasks_filters.py y test_tags.py.