### PR TITLE
feat: Subfase 9.3 – Mejora de la Reformulación de Títulos mediante Traducción + Parafraseo con IA

### DIFF
--- a/app/api/v1/endpoints/tasks_ai.py
+++ b/app/api/v1/endpoints/tasks_ai.py
@@ -11,7 +11,7 @@ from app.services.auth import get_current_user
 from app.schemas.responses import PRIORITIZED_TASK_EXAMPLE, GROUPED_TASKS_EXAMPLE, REWRITTEN_TASK_EXAMPLE
 from app.services.AI.priority_classifier import clasificar_prioridad
 from app.services.AI.task_organizer import agrupar_tareas_por_similitud
-from app.services.AI.reformulator import reformular_titulo
+from app.services.AI.reformulator import  reformular_titulo_con_traduccion
 import re
 
 router = APIRouter(prefix="/tasks/ai", tags=["Tareas con IA"])
@@ -98,13 +98,12 @@ async def rewrite_tasks(
 
     result = []
     for task in tasks:
-        reformulada = reformular_titulo(task.titulo)
-        if reformulada.strip().lower() == task.titulo.strip().lower():
-            reformulada += " (sin cambios sugeridos)"
+        resultado =  reformular_titulo_con_traduccion(task.titulo)
         result.append(RewrittenTask(
             id=task.id,
             original=task.titulo,
-            reformulada=reformulada
+            reformulada=resultado["reformulada"],
+            motivo=resultado["motivo"]
         ))
     return result
 

--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -82,3 +82,4 @@ class RewrittenTask(BaseModel):
     id : UUID
     original : str
     reformulada : str
+    motivo: str

--- a/app/services/AI/reformulator.py
+++ b/app/services/AI/reformulator.py
@@ -1,12 +1,39 @@
 from transformers import pipeline
 
-# Cargamos el modelo solo una vez
-parafraseador = pipeline("text2text-generation", model="humarin/chatgpt_paraphraser_on_T5_base")
+# Cargar modelos
+traductor_es_en = pipeline("translation", model="Helsinki-NLP/opus-mt-es-en")
+traductor_en_es = pipeline("translation", model="Helsinki-NLP/opus-mt-en-es")
+parafraseador_en = pipeline("text2text-generation", model="humarin/chatgpt_paraphraser_on_T5_base")
 
-# Función para reformular un título de tarea
-def reformular_titulo(titulo: str) -> str:
-    resultado = parafraseador(titulo, max_length=100, do_sample=True)
-    reformulado = resultado[0]["generated_text"]
-    if titulo not in reformulado:
-        reformulado = f"{reformulado} ({titulo})"
-    return reformulado
+def reformular_titulo_con_traduccion(titulo: str) -> dict:
+    try:
+        # ES → EN
+        traducido_en = traductor_es_en(titulo, max_length=100)[0]["translation_text"]
+
+        # Parafrasear en inglés
+        prompt = f"paraphrase: {traducido_en}"
+        parafraseado_en = parafraseador_en(prompt, max_length=100, do_sample=True)[0]["generated_text"].strip()
+
+        # EN → ES
+        reformulado_es = traductor_en_es(parafraseado_en, max_length=100)[0]["translation_text"].strip()
+
+        # Validación mínima
+        if reformulado_es.lower() == titulo.strip().lower():
+            return {
+                "reformulada": reformulado_es,
+                "cambio": False,
+                "motivo": "No se sugirieron cambios por la IA (traducción y reformulación)."
+            }
+        else:
+            return {
+                "reformulada": reformulado_es,
+                "cambio": True,
+                "motivo": "Reformulación generada mediante traducción y IA."
+            }
+
+    except Exception as e:
+        return {
+            "reformulada": titulo,
+            "cambio": False,
+            "motivo": f"Error durante la reformulación: {e}"
+        }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,9 @@ dependencies = [
   "sentence-transformers>=2.7.0",
   "celery[redis]~=5.4",
   "setfit",
+  "sentencepiece>=0.2.0",
+  "sacremoses==0.1.1",
+
 
   # ─── Miscelánea ────────────────────────────────clear──────────────────────
   "python-dotenv~=1.0"

--- a/tests/test_AI.py
+++ b/tests/test_AI.py
@@ -2,7 +2,7 @@ from uuid import UUID
 
 import pytest
 from httpx import AsyncClient
-from  app.services.AI.reformulator import reformular_titulo
+from app.services.AI.reformulator import reformular_titulo_con_traduccion
 from app.services.AI.task_organizer import agrupar_tareas_por_similitud
 from app.services.AI.priority_classifier import clasificar_prioridad
 from tests.utils import create_user_and_token, create_task
@@ -10,7 +10,8 @@ from tests.utils import create_user_and_token, create_task
 
 def test_local_reformulator():
     original = "Limpiar la cocina"
-    reformulada = reformular_titulo(original)
+    resultado = reformular_titulo_con_traduccion(original)
+    reformulada = resultado["reformulada"]
 
     print("\n Original:", original)
     print(" Reformulado:", reformulada)

--- a/tests/test_task_intelligence.py
+++ b/tests/test_task_intelligence.py
@@ -1,5 +1,6 @@
 import pytest
 from httpx import AsyncClient
+from app.services.AI.reformulator import reformular_titulo_con_traduccion
 from tests.utils import create_user_and_token, create_task
 
 @pytest.mark.asyncio
@@ -31,18 +32,11 @@ async def test_group_tasks_mock(async_client):
     data = response.json()
     assert "Limpieza" in data["grupos"] or "Trabajo/Estudios" in data["grupos"]
 
-@pytest.mark.asyncio
-async def test_rewrite_tasks_mock(async_client):
-    user, token = await create_user_and_token(async_client)
-    headers = {"Authorization": f"Bearer {token}"}
+def test_rewrite_tasks_mock():
+    original = "Revisión prácticas"
+    resultado = reformular_titulo_con_traduccion(original)
+    assert isinstance(resultado, dict)
+    assert resultado["reformulada"].strip() != ""
+    assert resultado["reformulada"].lower() != original.lower()
+    assert resultado["cambio"] is True
 
-    await create_task(async_client, token, {"titulo": "Lavar", "categoria": "OTRO"})
-    await create_task(async_client, token, {"titulo": "Revisión prácticas", "categoria": "OTRO"})
-
-    response = await async_client.post("/api/v1/tasks/ai/rewrite", headers=headers, json={})
-    assert response.status_code == 200
-    data = response.json()
-    assert len(data) == 2
-    for item in data:
-        assert "reformulada" in item
-        assert item["original"] in item["reformulada"]


### PR DESCRIPTION

# 🧠 Subfase 9.3 – Mejora de la Reformulación de Títulos mediante Traducción + Parafraseo con IA

## 🎯 Objetivo
Mejorar la reformulación automática de títulos de tareas para hacerlos más claros y específicos, utilizando una estrategia más confiable para el idioma español basada en **traducción ida y vuelta (ES → EN → ES)** y **modelos de parafraseo en inglés**.

---

## 🧩 Situación inicial

La versión anterior usaba un modelo de parafraseo `T5` sin tener en cuenta el idioma:

```python
pipeline("text2text-generation", model="humarin/chatgpt_paraphraser_on_T5_base")
```

Este modelo fue entrenado en inglés, por lo que al aplicarse directamente a títulos en español producía errores como:

- Traducciones incorrectas o incompletas
- Palabras inventadas
- Reformulaciones incoherentes

---

## ❌ Problemas detectados

| Problema | Ejemplo |
|---------|---------|
| Traducción incorrecta | `"Enviar currículum urgente"` → `"Urgent demand for enviar..."`
| Palabras inventadas | `"Organizar escritorio"` → `"Concepecer escortorios?"`
| Reformulación sin cambios útiles | `"Comprar papel higiénico"` → `"Comprar papel higiénico."`

---

## ✅ Solución aplicada: Reformulación multilingüe con traducción ida y vuelta

Se implementó una función que:

1. **Traduce el título del español al inglés**
2. **Aplica parafraseo en inglés con el modelo T5**
3. **Traduce nuevamente al español**

Esto permite aprovechar lo mejor de ambos mundos:
- Precisión lingüística en español
- Potencia de modelos IA entrenados en inglés

---

## 🧠 Implementación técnica

```python
traductor_es_en = pipeline("translation", model="Helsinki-NLP/opus-mt-es-en")
traductor_en_es = pipeline("translation", model="Helsinki-NLP/opus-mt-en-es")
parafraseador_en = pipeline("text2text-generation", model="humarin/chatgpt_paraphraser_on_T5_base")

def reformular_titulo(titulo: str) -> dict:
    # 1. Traducir ES → EN
    # 2. Parafrasear en inglés
    # 3. Traducir EN → ES
    # 4. Detectar si hubo cambios reales
    ...
```

También se añadió un campo `"motivo"` que explica si la IA sugirió un cambio o no.

---

## 📄 Ejemplo de salida esperada

```json
{
  "id": "abc123",
  "original": "Llamar al médico para cita urgente",
  "reformulada": "Solicitar una cita médica urgente",
  "motivo": "Reformulación generada mediante traducción y IA."
}
```

---

## 🧪 Validación

- Se actualizó el test `test_rewrite_tasks_real` para validar que las tareas reformuladas tienen título distinto.
- Se actualizó `test_rewrite_tasks_mock` para usar la nueva función.
- Se instaló la librería `sentencepiece`, requerida por los modelos de traducción.

---

## ✅ Ventajas obtenidas

| Mejora | Resultado |
|--------|-----------|
| Mayor coherencia en español | Traducciones precisas y parafraseo natural |
| Mejor comunicación al usuario | Se explica si se reformuló o no |
| Evita errores lingüísticos | El modelo trabaja en su idioma nativo (inglés) y se traduce correctamente |
| Modularidad | Toda la lógica está encapsulada en `reformulator.py` |

---

## 📌 Conclusión

Este cambio mejora drásticamente la utilidad y calidad de la reformulación de tareas, especialmente en idioma español, combinando múltiples modelos IA de forma coordinada para obtener resultados claros, útiles y comprensibles.



---

## ⚠️ Limitaciones detectadas tras pruebas reales

Aunque el sistema de reformulación con traducción y parafraseo ha demostrado ser **mucho más robusto que la versión anterior**, aún se observaron ciertos **comportamientos problemáticos** que deben documentarse para futuras mejoras.

### 🧾 Ejemplos reales y observaciones

| Título original | Reformulación IA | Observación |
|-----------------|------------------|-------------|
| Comprar papel higiénico | Compra papel higiénico. | Apenas aporta valor añadido. |
| Enviar currículum urgente | Enviar un curriculum vitae con necesidades urgentes. | Traducción literal poco natural. |
| Llamar al médico para cita urgente | Concierte una cita con un médico para situaciones urgentes. | Demasiado formal y alejado del lenguaje común. |
| Organizar escritorio | Reorganice el espacio de trabajo en la pantalla del ordenador. | Asume contexto digital erróneamente. |
| Ver documental pendiente | Ver documental pendiente » . | Puntuación corrupta y sin mejora efectiva. |

---

## 🔍 Causas comunes de error

- Traducción literal que rompe la fluidez en español
- Interpretación incorrecta del contexto por parte del modelo
- Reformulaciones innecesarias o poco útiles para frases simples
- Errores sintácticos residuales de puntuación

---

## ✅ Propuestas de mejora futura

| Mejora | Descripción | Impacto esperado |
|--------|-------------|------------------|
| Validación semántica post-reformulación | Medir si el cambio aporta valor o es redundante | Evita reformulaciones innecesarias |
| Reglas heurísticas de estilo | Filtrar frases demasiado formales o forzadas | Mejor naturalidad |
| Entrenamiento específico para tareas | Fine-tuning con dataset como PAWS-X (español) | Precisión contextual |
| Reformulación opcional según complejidad | Omitir parafraseo si el título es corto y claro | Eficiencia y claridad |

---
