### PR TITLE
Subfase Fronted 5 – Marcar tarea como completada

### DIFF
--- a/prioritask-frontend/src/components/TaskForm.tsx
+++ b/prioritask-frontend/src/components/TaskForm.tsx
@@ -8,6 +8,7 @@ const TaskForm = () => {
   const [categoria, setCategoria] = useState("LIMPIEZA");
   const [peso, setPeso] = useState(1);
   const [dueDate, setDueDate] = useState("");
+  const [estado, setEstado] = useState("TODO");
   const [error, setError] = useState("");
 
   const { taskId } = useParams();
@@ -32,12 +33,13 @@ const TaskForm = () => {
               Authorization: `Bearer ${token}`,
             },
           });
-          const { titulo, descripcion, categoria, peso, due_date } = response.data;
+          const { titulo, descripcion, categoria, peso, due_date, estado } = response.data;
           setTitulo(titulo);
           setDescripcion(descripcion);
           setCategoria(categoria);
           setPeso(peso);
           setDueDate(due_date);
+          setEstado(estado);
         } catch (err) {
           console.error(err);
           setError("Error al cargar la tarea");
@@ -52,18 +54,20 @@ const TaskForm = () => {
     setError("");
 
     const token = localStorage.getItem("token");
+    const taskData = {
+      titulo,
+      descripcion,
+      categoria,
+      peso,
+      due_date: formatearFecha(dueDate),
+      estado,
+    };
 
     try {
       if (taskId) {
         await axios.put(
           `http://localhost:8000/api/v1/tasks/${taskId}`,
-          {
-            titulo,
-            descripcion,
-            categoria,
-            peso,
-            due_date: formatearFecha(dueDate),
-          },
+          taskData,
           {
             headers: {
               Authorization: `Bearer ${token}`,
@@ -73,13 +77,7 @@ const TaskForm = () => {
       } else {
         await axios.post(
           "http://localhost:8000/api/v1/tasks",
-          {
-            titulo,
-            descripcion,
-            categoria,
-            peso,
-            due_date: dueDate,
-          },
+          taskData,
           {
             headers: {
               Authorization: `Bearer ${token}`,
@@ -155,6 +153,20 @@ const TaskForm = () => {
             value={dueDate}
             onChange={(e) => setDueDate(e.target.value)}
           />
+        </div>
+
+        <div className="mb-3">
+          <label htmlFor="estado" className="form-label">Estado</label>
+          <select
+            id="estado"
+            className="form-select"
+            value={estado}
+            onChange={(e) => setEstado(e.target.value)}
+          >
+            <option value="TODO">Pendiente</option>
+            <option value="IN_PROGRESS">En progreso</option>
+            <option value="DONE">Completada</option>
+          </select>
         </div>
 
         <button type="submit" className="btn btn-primary">

--- a/prioritask-frontend/src/components/TaskList.tsx
+++ b/prioritask-frontend/src/components/TaskList.tsx
@@ -53,6 +53,25 @@ const TaskList = () => {
     }
   };
 
+  const marcarComoCompletada = async (taskId: string) => {
+    try {
+      const token = localStorage.getItem("token");
+      await axios.patch(
+        `http://localhost:8000/api/v1/tasks/${taskId}`,
+        { estado: "DONE" },
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+      // Recargar tareas
+      fetchTareas();
+    } catch (error) {
+      console.error("Error al marcar como completada:", error);
+    }
+  };
+
   useEffect(() => {
     fetchTareas();
   }, []);
@@ -77,7 +96,9 @@ const TaskList = () => {
           {tareas.map((tarea) => (
             <li
               key={tarea.id}
-              className="list-group-item d-flex justify-content-between align-items-center"
+              className={`list-group-item d-flex justify-content-between align-items-center ${
+                tarea.estado === "DONE" ? "bg-light text-muted" : ""
+              }`}
             >
               <div>
                 <strong>{tarea.titulo}</strong> <br />
@@ -87,6 +108,14 @@ const TaskList = () => {
               </div>
 
               <div>
+                {tarea.estado !== "DONE" && (
+                  <button
+                    className="btn btn-sm btn-success me-2"
+                    onClick={() => marcarComoCompletada(tarea.id)}
+                  >
+                    ✅ Completar
+                  </button>
+                )}
                 <button
                   className="btn btn-sm btn-outline-primary me-2"
                   onClick={() => navigate(`/tasks/edit/${tarea.id}`)}


### PR DESCRIPTION
# 📘 Subfase Fronted 5 – Marcar tarea como completada

## 🎯 Objetivo
Permitir a los usuarios marcar tareas como completadas mediante un botón en la lista de tareas, cambiando su estado a `DONE`.

## 🧩 Situación inicial

Hasta esta subfase, las tareas podían ser creadas, editadas y eliminadas, pero no se disponía de una funcionalidad explícita en la interfaz para marcarlas como completadas. No existía un botón visible ni un endpoint específico que facilitara esta acción parcialmente (con `PATCH`), lo cual era necesario para mantener la trazabilidad y eficiencia.


## ❌ Problemas detectados


| Problema | Descripción |
|---------|-------------|
| Método no permitido | El intento de usar `PATCH` resultaba en un error `405 Method Not Allowed`, ya que el backend no lo soportaba. |
| Falta de botón UI | No había un botón para cambiar el estado desde la interfaz. |
| Estética  | No se distinguían visualmente las tareas completadas. |


## ✅ Cambios implementados

### 🔧 Backend (FastAPI)
- Se añadió un nuevo endpoint `PATCH /tasks/{task_id}` para permitir la actualización parcial del estado de una tarea.
- Se agregó una lógica para:
  - Verificar permisos del usuario.
  - Registrar el cambio en `TaskHistory`.
  - Persistir solo el campo modificado (`estado`).

### 💻 Frontend (React + Axios)
- Se añadió un botón **"Marcar como completada"** en cada tarea con estado distinto a `DONE`.
- Al hacer clic, se llama a `PATCH /tasks/{task_id}` enviando solo `{ estado: "DONE" }`.
- Tras completarse, se recarga la lista de tareas actualizadas.


## 🧪 Resultado final
- Se puede marcar una tarea como completada sin editar todos los campos.
- El historial queda registrado en la base de datos.