### PR TITLE
Fix error response for task history

### DIFF
--- a/app/api/v1/endpoints/tasks.py
+++ b/app/api/v1/endpoints/tasks.py
@@ -16,7 +16,11 @@ from app.models.task import Task, TaskHistory, EstadoTarea
 from app.schemas.task import TaskCreate, TaskRead, TaskUpdate, TaskAssignmentCreate, TaskAssignmentRead
 from app.models.user import Usuario
 from app.services.task_assignment import TaskAssignmentService
-from app.schemas.responses import ERROR_BAD_REQUEST, ERROR_ROOM_NOT_FOUND, ERROR_FORBIDDEN
+from app.schemas.responses import (
+    ERROR_BAD_REQUEST,
+    ERROR_FORBIDDEN,
+    ERROR_TASK_HISTORY_NOT_FOUND,
+)
 from pydantic import ValidationError
 
 router = APIRouter(prefix="/tasks", tags=["Gestión de tareas"])
@@ -165,7 +169,7 @@ async def get_task_history(
     )
     history = result.all()
     if not history:
-        return ERROR_ROOM_NOT_FOUND
+        return ERROR_TASK_HISTORY_NOT_FOUND
     return history
 
 @router.get("/{task_id}", response_model=TaskRead, summary="Obtener tarea específica", description="Obtiene una tarea específica del usuario actual.")

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -31,6 +31,12 @@ ERROR_FORBIDDEN = JSONResponse(
     content={"detail": "Acceso prohibido. No tiene permisos para realizar esta acción."}
 )
 
+# ERROR_TASK_HISTORY_NOT_FOUND: Indica que el historial de la tarea no fue encontrado.
+ERROR_TASK_HISTORY_NOT_FOUND = JSONResponse(
+    status_code=404,
+    content={"detail": "Historial de tarea no encontrado."}
+)
+
 # ERROR_INTERNAL_SERVER_ERROR: Indica que ocurrió un problema inesperado en el servidor.
 ERROR_INTERNAL_SERVER_ERROR = JSONResponse(
     status_code=500,


### PR DESCRIPTION
## Summary
- return correct error when task history doesn't exist
- add new `ERROR_TASK_HISTORY_NOT_FOUND` response constant

## Testing
- `pytest -q` *(fails: ModuleNotFoundError for `pytest_asyncio`)*

------
https://chatgpt.com/codex/tasks/task_e_684064da4a10832cad2a21bbf5961273