### PR TITLE
Add helper for dev dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Install deps
         run: |
-          pip install -e .[dev]
+          pip install -r requirements-dev.txt
 
       - name: Lint
         run: |

--- a/README.md
+++ b/README.md
@@ -47,7 +47,10 @@ cd prioritask
 ```bash
 python -m venv .venv
 source .venv/bin/activate  # o .venv\Scripts\activate en Windows
+# Instala las dependencias de desarrollo (incluyen pytest_asyncio)
 pip install -e .[dev]
+# O bien puedes usar el archivo helper
+# pip install -r requirements-dev.txt
 ```
 
 ### 3. Configura el entorno

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+# Development and testing dependencies
+-e .[dev]


### PR DESCRIPTION
## Summary
- add `requirements-dev.txt` with extras
- document dev dependencies and optional helper in README
- update CI to install via requirements-dev.txt

## Testing
- `pip install -r requirements-dev.txt` *(fails: could not find a version that satisfies the requirement setuptools>=40.8.0)*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pytest_asyncio')*


------
https://chatgpt.com/codex/tasks/task_e_6840779f0454832c9a36f296292fc0a0