### PR TITLE
Mejorar la integración de la API en el frontend.

### DIFF
--- a/prioritask-frontend/.env.example
+++ b/prioritask-frontend/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=http://localhost:8000/api/v1

--- a/prioritask-frontend/src/App.tsx
+++ b/prioritask-frontend/src/App.tsx
@@ -2,6 +2,8 @@ import { BrowserRouter, Routes, Route, Navigate, useLocation } from "react-route
 import Login from "./auth/Login";
 import Register from "./auth/Register";
 import Dashboard from "./pages/Dashboard";
+import Tags from "./pages/Tags";
+import Profile from "./pages/Profile";
 import Sidebar from "./components/Sidebar";
 import TaskList from "./components/TaskList";
 import TaskForm from "./components/TaskForm";
@@ -22,6 +24,8 @@ const AppContent = () => {
           <Route path="/tasks" element={<TaskList />} />
           <Route path="/tasks/create" element={<TaskForm />} />
           <Route path="/tasks/edit/:taskId" element={<TaskForm />} />
+          <Route path="/tags" element={<Tags />} />
+          <Route path="/profile" element={<Profile />} />
         </Routes>
       </div>
     </div>

--- a/prioritask-frontend/src/api.ts
+++ b/prioritask-frontend/src/api.ts
@@ -1,0 +1,43 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: import.meta.env.VITE_API_URL || "http://localhost:8000/api/v1",
+});
+
+api.interceptors.request.use((config) => {
+  const token = localStorage.getItem("token");
+  if (token) {
+    config.headers = config.headers || {};
+    config.headers.Authorization = `Bearer ${token}`;
+  }
+  return config;
+});
+
+api.interceptors.response.use(
+  (response) => response,
+  async (error) => {
+    const originalRequest = error.config;
+    if (
+      error.response &&
+      error.response.status === 401 &&
+      !originalRequest._retry
+    ) {
+      originalRequest._retry = true;
+      try {
+        const refresh = await api.post("/auth/refresh");
+        const { access_token } = refresh.data;
+        localStorage.setItem("token", access_token);
+        originalRequest.headers = originalRequest.headers || {};
+        originalRequest.headers.Authorization = `Bearer ${access_token}`;
+        return api(originalRequest);
+      } catch (refreshError) {
+        localStorage.removeItem("token");
+        window.location.href = "/login";
+        return Promise.reject(refreshError);
+      }
+    }
+    return Promise.reject(error);
+  }
+);
+
+export default api;

--- a/prioritask-frontend/src/auth/Login.tsx
+++ b/prioritask-frontend/src/auth/Login.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import axios from "axios";
+import api from "../api";
 import { useNavigate } from "react-router-dom";
 import styles from "./Login.module.css";
 
@@ -12,7 +12,7 @@ export default function Login() {
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const response = await axios.post("http://localhost:8000/api/v1/auth/login", {
+      const response = await api.post("/auth/login", {
         email,
         password,
       });

--- a/prioritask-frontend/src/auth/Register.tsx
+++ b/prioritask-frontend/src/auth/Register.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import axios from "axios";
+import api from "../api";
 import { useNavigate } from "react-router-dom";
 import styles from "./Login.module.css";
 
@@ -13,7 +13,7 @@ export default function Register() {
   const handleRegister = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await axios.post("http://localhost:8000/api/v1/auth/register", {
+      await api.post("/auth/register", {
         nombre: username,
         email,
         password,

--- a/prioritask-frontend/src/components/Sidebar.tsx
+++ b/prioritask-frontend/src/components/Sidebar.tsx
@@ -31,6 +31,11 @@ const Sidebar = () => {
             <span role="img" aria-label="Tasks">📝</span> Tareas
           </NavLink>
         </li>
+        <li>
+          <NavLink to="/tags" className={({ isActive }) => isActive ? "active" : ""}>
+            <span role="img" aria-label="Tags">🏷️</span> Etiquetas
+          </NavLink>
+        </li>
 
         <li className="nav-bottom">
           <NavLink to="/profile" className={({ isActive }) => isActive ? "active" : ""}>

--- a/prioritask-frontend/src/components/TaskForm.tsx
+++ b/prioritask-frontend/src/components/TaskForm.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import axios from "axios";
+import api from "../api";
 import { useNavigate, useParams } from "react-router-dom";
 
 const TaskForm = () => {
@@ -26,13 +26,8 @@ const TaskForm = () => {
   useEffect(() => {
     if (taskId) {
       const fetchTask = async () => {
-        const token = localStorage.getItem("token");
         try {
-          const response = await axios.get(`http://localhost:8000/api/v1/tasks/${taskId}`, {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          });
+          const response = await api.get(`/tasks/${taskId}`);
           const { titulo, descripcion, categoria, peso, due_date, estado } = response.data;
           setTitulo(titulo);
           setDescripcion(descripcion);
@@ -53,7 +48,6 @@ const TaskForm = () => {
     e.preventDefault();
     setError("");
 
-    const token = localStorage.getItem("token");
     const taskData = {
       titulo,
       descripcion,
@@ -65,25 +59,9 @@ const TaskForm = () => {
 
     try {
       if (taskId) {
-        await axios.put(
-          `http://localhost:8000/api/v1/tasks/${taskId}`,
-          taskData,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        );
+        await api.put(`/tasks/${taskId}`, taskData);
       } else {
-        await axios.post(
-          "http://localhost:8000/api/v1/tasks",
-          taskData,
-          {
-            headers: {
-              Authorization: `Bearer ${token}`,
-            },
-          }
-        );
+        await api.post("/tasks", taskData);
       }
 
       navigate("/tasks");

--- a/prioritask-frontend/src/components/TaskList.tsx
+++ b/prioritask-frontend/src/components/TaskList.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 import { useNavigate } from "react-router-dom";
 import debounce from "lodash/debounce";
 
@@ -32,8 +32,7 @@ const TaskList = () => {
       if (fechaLimite) params.due_date_max = fechaLimite;
       if (busqueda) params.search = busqueda;
 
-      const res = await axios.get("http://localhost:8000/api/v1/tasks", {
-        headers: { Authorization: `Bearer ${token}` },
+      const res = await api.get("/tasks", {
         params,
       });
 
@@ -53,11 +52,7 @@ const TaskList = () => {
 
     try {
       const token = localStorage.getItem("token");
-      await axios.delete(`http://localhost:8000/api/v1/tasks/${id}`, {
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      });
+      await api.delete(`/tasks/${id}`);
       setTareas(tareas.filter((t) => t.id !== id));
     } catch (error) {
       console.error("Error al eliminar tarea:", error);
@@ -68,15 +63,7 @@ const TaskList = () => {
   const marcarComoCompletada = async (taskId: string) => {
     try {
       const token = localStorage.getItem("token");
-      await axios.patch(
-        `http://localhost:8000/api/v1/tasks/${taskId}`,
-        { estado: "DONE" },
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
+      await api.patch(`/tasks/${taskId}`, { estado: "DONE" });
       // Recargar tareas
       fetchTareas();
     } catch (error) {

--- a/prioritask-frontend/src/pages/Dashboard.tsx
+++ b/prioritask-frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 import { FaTasks, FaCheckCircle, FaExclamationTriangle } from "react-icons/fa";
 import styles from "./Dashboard.module.css";
 
@@ -8,10 +8,7 @@ const Dashboard = () => {
 
   useEffect(() => {
     const fetchTareas = async () => {
-      const token = localStorage.getItem("token");
-      const res = await axios.get("http://localhost:8000/api/v1/tasks", {
-        headers: { Authorization: `Bearer ${token}` },
-      });
+      const res = await api.get("/tasks");
       setTareas(res.data);
     };
 

--- a/prioritask-frontend/src/pages/Profile.tsx
+++ b/prioritask-frontend/src/pages/Profile.tsx
@@ -1,0 +1,36 @@
+import { useEffect, useState } from "react";
+import api from "../api";
+
+interface User {
+  id: string;
+  nombre: string;
+  email: string;
+}
+
+const Profile = () => {
+  const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const fetchUser = async () => {
+      try {
+        const res = await api.get("/auth/me");
+        setUser(res.data);
+      } catch (err) {
+        console.error(err);
+      }
+    };
+    fetchUser();
+  }, []);
+
+  if (!user) return <p>Cargando...</p>;
+
+  return (
+    <div className="container mt-4">
+      <h2>Perfil</h2>
+      <p><strong>Nombre:</strong> {user.nombre}</p>
+      <p><strong>Email:</strong> {user.email}</p>
+    </div>
+  );
+};
+
+export default Profile;

--- a/prioritask-frontend/src/pages/Tags.tsx
+++ b/prioritask-frontend/src/pages/Tags.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import api from "../api";
+
+interface Tag {
+  id: string;
+  nombre: string;
+}
+
+const Tags = () => {
+  const [tags, setTags] = useState<Tag[]>([]);
+  const [nombre, setNombre] = useState("");
+  const [error, setError] = useState("");
+
+  const fetchTags = async () => {
+    try {
+      const res = await api.get("/tags");
+      setTags(res.data);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  useEffect(() => {
+    fetchTags();
+  }, []);
+
+  const handleCreate = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    try {
+      await api.post("/tags", { nombre });
+      setNombre("");
+      fetchTags();
+    } catch (err: any) {
+      setError(err.response?.data?.detail || "Error al crear etiqueta");
+    }
+  };
+
+  const handleDelete = async (id: string) => {
+    if (!confirm("¿Eliminar etiqueta?")) return;
+    try {
+      await api.delete(`/tags/${id}`);
+      setTags(tags.filter((t) => t.id !== id));
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h2>Etiquetas</h2>
+      <form onSubmit={handleCreate} className="mb-3 d-flex gap-2">
+        <input
+          className="form-control"
+          value={nombre}
+          onChange={(e) => setNombre(e.target.value)}
+          placeholder="Nueva etiqueta"
+        />
+        <button className="btn btn-primary" type="submit">
+          Crear
+        </button>
+      </form>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <ul className="list-group">
+        {tags.map((tag) => (
+          <li key={tag.id} className="list-group-item d-flex justify-content-between align-items-center">
+            {tag.nombre}
+            <button className="btn btn-sm btn-outline-danger" onClick={() => handleDelete(tag.id)}>
+              Eliminar
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+};
+
+export default Tags;


### PR DESCRIPTION
## Resumen

- Añadir cliente Axios centralizado con renovación de token  
- Crear páginas de perfil y etiquetas  
- Conectar las nuevas páginas al enrutador y a la barra lateral  
- Usar el cliente de API en los componentes existentes  
- Proporcionar `.env.example` con `VITE_API_URL`
