### PR TITLE
Add task assignment form

### DIFF
--- a/prioritask-frontend/src/App.tsx
+++ b/prioritask-frontend/src/App.tsx
@@ -7,6 +7,7 @@ import Profile from "./pages/Profile";
 import Sidebar from "./components/Sidebar";
 import TaskList from "./components/TaskList";
 import TaskForm from "./components/TaskForm";
+import AssignTaskForm from "./components/AssignTaskForm";
 
 const AppContent = () => {
   const location = useLocation();
@@ -24,6 +25,7 @@ const AppContent = () => {
           <Route path="/tasks" element={<TaskList />} />
           <Route path="/tasks/create" element={<TaskForm />} />
           <Route path="/tasks/edit/:taskId" element={<TaskForm />} />
+          <Route path="/tasks/assign" element={<AssignTaskForm />} />
           <Route path="/tags" element={<Tags />} />
           <Route path="/profile" element={<Profile />} />
         </Routes>

--- a/prioritask-frontend/src/components/AssignTaskForm.tsx
+++ b/prioritask-frontend/src/components/AssignTaskForm.tsx
@@ -1,0 +1,109 @@
+import { useState } from "react";
+import api from "../api";
+
+interface Assignment {
+  id: number;
+  task_id: string;
+  user_id: string;
+  asignado_por: string;
+  fecha: string;
+}
+
+const AssignTaskForm = () => {
+  const [userId, setUserId] = useState("");
+  const [taskId, setTaskId] = useState("");
+  const [assignments, setAssignments] = useState<Assignment[]>([]);
+  const [error, setError] = useState("");
+
+  const fetchAssignments = async () => {
+    if (!userId) return;
+    try {
+      const res = await api.get(`/tasks/assigned/${userId}`);
+      setAssignments(res.data);
+    } catch (err: any) {
+      console.error(err);
+      setError(err.response?.data?.detail || "Error al obtener asignaciones");
+    }
+  };
+
+  const handleAssign = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError("");
+    try {
+      await api.post("/tasks/assign", {
+        task_id: taskId,
+        user_id: userId,
+      });
+      setTaskId("");
+      fetchAssignments();
+    } catch (err: any) {
+      console.error(err);
+      setError(err.response?.data?.detail || "Error al asignar tarea");
+    }
+  };
+
+  const removeAssignment = async (task: string) => {
+    try {
+      await api.delete(`/tasks/${task}/assignees/${userId}`);
+      fetchAssignments();
+    } catch (err: any) {
+      console.error(err);
+      setError(err.response?.data?.detail || "Error al eliminar asignación");
+    }
+  };
+
+  return (
+    <div className="container mt-4">
+      <h2>Asignar tareas</h2>
+      {error && <div className="alert alert-danger">{error}</div>}
+      <form onSubmit={handleAssign} className="mb-4">
+        <div className="mb-3">
+          <label className="form-label">ID de usuario</label>
+          <input
+            type="text"
+            className="form-control"
+            value={userId}
+            onChange={(e) => setUserId(e.target.value)}
+            onBlur={fetchAssignments}
+            required
+          />
+        </div>
+        <div className="mb-3">
+          <label className="form-label">ID de tarea</label>
+          <input
+            type="text"
+            className="form-control"
+            value={taskId}
+            onChange={(e) => setTaskId(e.target.value)}
+            required
+          />
+        </div>
+        <button type="submit" className="btn btn-primary">
+          Asignar
+        </button>
+      </form>
+
+      {assignments.length > 0 && (
+        <div>
+          <h5>Tareas asignadas al usuario</h5>
+          <ul className="list-group">
+            {assignments.map((a) => (
+              <li key={a.id} className="list-group-item d-flex justify-content-between align-items-center">
+                <span>{a.task_id}</span>
+                <button
+                  className="btn btn-sm btn-outline-danger"
+                  onClick={() => removeAssignment(a.task_id)}
+                >
+                  Quitar
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default AssignTaskForm;
+

--- a/prioritask-frontend/src/components/Sidebar.tsx
+++ b/prioritask-frontend/src/components/Sidebar.tsx
@@ -32,6 +32,11 @@ const Sidebar = () => {
           </NavLink>
         </li>
         <li>
+          <NavLink to="/tasks/assign" className={({ isActive }) => isActive ? "active" : ""}>
+            <span role="img" aria-label="Assign">🤝</span> Asignar
+          </NavLink>
+        </li>
+        <li>
           <NavLink to="/tags" className={({ isActive }) => isActive ? "active" : ""}>
             <span role="img" aria-label="Tags">🏷️</span> Etiquetas
           </NavLink>

--- a/prioritask.egg-info/SOURCES.txt
+++ b/prioritask.egg-info/SOURCES.txt
@@ -11,6 +11,8 @@ tests/test_AI.py
 tests/test_auth_endpoints.py
 tests/test_auth_service.py
 tests/test_get_task_history.py
+tests/test_patch_task.py
+tests/test_patch_task_status.py
 tests/test_rooms.py
 tests/test_rooms_persistence.py
 tests/test_sample.py


### PR DESCRIPTION

# Implementación del formulario de asignación de tareas

## Resumen

- Se añadió el componente `AssignTaskForm` para gestionar asignaciones de tareas.
- Permite asignar tareas a usuarios, listar asignaciones existentes y eliminarlas.
- Se integró la nueva ruta `/tasks/assign` en el enrutador (`App.tsx`) y en la barra lateral (`Sidebar.tsx`).

## Detalles del componente

El componente `AssignTaskForm`:

- Utiliza `useState` para manejar el ID del usuario, el ID de la tarea, errores y las asignaciones actuales.
- Al introducir el ID de usuario, se obtienen automáticamente las tareas asignadas a dicho usuario.
- Al enviar el formulario, se asigna la tarea correspondiente al usuario indicado.
- Las asignaciones existentes pueden eliminarse mediante botones individuales.

Ruta del archivo: `prioritask-frontend/src/components/AssignTaskForm.tsx`

## Integración en el enrutador (`App.tsx`)

Se añadió la siguiente línea dentro del componente `Routes`:

```tsx
<Route path="/tasks/assign" element={<AssignTaskForm />} />
```

También se importó el componente:

```tsx
import AssignTaskForm from "./components/AssignTaskForm";
```

## Navegación en la barra lateral (`Sidebar.tsx`)

Se añadió un nuevo enlace de navegación para acceder al formulario de asignación:

```tsx
<li>
  <NavLink to="/tasks/assign" className={({ isActive }) => isActive ? "active" : ""}>
    <span role="img" aria-label="Assign">🤝</span> Asignar
  </NavLink>
</li>
```

## Pruebas

Las pruebas pasaron correctamente utilizando:

```
✅ pytest -q
```

### Advertencias observadas

- Uso de `crypt` en desuso en `passlib` (previsto para eliminación en Python 3.13).
- Uso de `datetime.utcnow()` en `pydantic`, también previsto para eliminación futura.

---