### PR TITLE
Add AI priority suggestion endpoint and UI

### DIFF
--- a/app/schemas/task.py
+++ b/app/schemas/task.py
@@ -99,3 +99,12 @@ class RewrittenTask(BaseModel):
     original : str
     reformulada : str
     motivo: str
+
+class PrioritySuggestRequest(BaseModel):
+    titulo: str
+    descripcion: Optional[str] = None
+    due_date: Optional[datetime] = None
+
+class PrioritySuggestion(BaseModel):
+    prioridad: str
+    motivo: str

--- a/prioritask-frontend/src/components/TaskForm.tsx
+++ b/prioritask-frontend/src/components/TaskForm.tsx
@@ -19,6 +19,7 @@ const TaskForm = () => {
   const [error, setError] = useState("");
   const [tags, setTags] = useState<Tag[]>([]);
   const [selectedTags, setSelectedTags] = useState<{ value: string; label: string }[]>([]);
+  const [sugerencia, setSugerencia] = useState<{ prioridad: string; motivo: string } | null>(null);
 
   const { taskId } = useParams();
   const navigate = useNavigate();
@@ -77,6 +78,28 @@ const TaskForm = () => {
       fetchTask();
     }
   }, [taskId, tags]);
+
+  const prioridadAPeso = (p: string) => {
+    if (p === "alta") return 5;
+    if (p === "media") return 3;
+    return 1;
+  };
+
+  const handleSuggest = async () => {
+    try {
+      const res = await api.post("/tasks/ai/suggest", {
+        titulo,
+        descripcion,
+        due_date: dueDate ? formatearFecha(dueDate) : undefined,
+      });
+      const { prioridad, motivo } = res.data;
+      setPeso(prioridadAPeso(prioridad));
+      setSugerencia({ prioridad, motivo });
+    } catch (err) {
+      console.error(err);
+      alert("Error al obtener sugerencia");
+    }
+  };
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -165,6 +188,20 @@ const TaskForm = () => {
             max="5"
           />
         </div>
+        <button
+          type="button"
+          className="btn btn-outline-secondary mb-2"
+          onClick={handleSuggest}
+        >
+          🧠 Sugerir prioridad
+        </button>
+        {sugerencia && (
+          <div className="alert alert-info p-2" role="alert">
+            Prioridad sugerida: <strong>{sugerencia.prioridad}</strong> -
+            {" "}
+            {sugerencia.motivo}
+          </div>
+        )}
 
         <div className="mb-3">
           <label>Fecha de vencimiento</label>

--- a/tests/test_AI.py
+++ b/tests/test_AI.py
@@ -153,3 +153,23 @@ async def test_rewrite_tasks_real(async_client: AsyncClient):
         assert "reformulada" in tarea
         assert tarea["reformulada"].strip() != ""
         # Puede estar marcada como "sin cambios sugeridos" si no cambió
+
+@pytest.mark.asyncio
+async def test_suggest_priority(async_client: AsyncClient):
+    user, token = await create_user_and_token(async_client)
+    headers = {"Authorization": f"Bearer {token}"}
+
+    response = await async_client.post(
+        "/api/v1/tasks/ai/suggest",
+        headers=headers,
+        json={
+            "titulo": "Entregar informe urgente",
+            "descripcion": "Debe enviarse hoy",
+        },
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert "prioridad" in data
+    assert data["prioridad"] in ["alta", "media", "baja"]
+    assert "motivo" in data


### PR DESCRIPTION
## 📝 Resumen

- Se añadió un nuevo endpoint /tasks/ai/suggest que analiza palabras clave de urgencia y fechas de vencimiento para proponer un nivel de prioridad para una tarea.

- Se introdujeron los esquemas PrioritySuggestRequest y PrioritySuggestion para la nueva API.

- Se mejoró el formulario de tareas con un botón “🧠 Sugerir prioridad” que aplica el peso de prioridad sugerido y muestra una insignia informativa.