### PR TITLE
Add AI grouping and rewriting frontend

### DIFF
--- a/prioritask-frontend/src/App.tsx
+++ b/prioritask-frontend/src/App.tsx
@@ -4,6 +4,8 @@ import Register from "./auth/Register";
 import Dashboard from "./pages/Dashboard";
 import Tags from "./pages/Tags";
 import Profile from "./pages/Profile";
+import GroupedTasks from "./pages/GroupedTasks";
+import RewriteTitles from "./pages/RewriteTitles";
 import Sidebar from "./components/Sidebar";
 import TaskList from "./components/TaskList";
 import TaskForm from "./components/TaskForm";
@@ -27,6 +29,8 @@ const AppContent = () => {
           <Route path="/tasks/create" element={<TaskForm />} />
           <Route path="/tasks/edit/:taskId" element={<TaskForm />} />
           <Route path="/tasks/assign" element={<AssignTaskForm />} />
+          <Route path="/tasks/grouped" element={<GroupedTasks />} />
+          <Route path="/tasks/rewrite" element={<RewriteTitles />} />
           <Route path="/tags" element={<Tags />} />
           <Route path="/profile" element={<Profile />} />
         </Routes>

--- a/prioritask-frontend/src/components/Sidebar.tsx
+++ b/prioritask-frontend/src/components/Sidebar.tsx
@@ -32,6 +32,11 @@ const Sidebar = () => {
           </NavLink>
         </li>
         <li>
+          <NavLink to="/tasks/grouped" className={({ isActive }) => isActive ? "active" : ""}>
+            <span role="img" aria-label="Grouped">🧠</span> Agrupadas
+          </NavLink>
+        </li>
+        <li>
           <NavLink to="/tasks/assign" className={({ isActive }) => isActive ? "active" : ""}>
             <span role="img" aria-label="Assign">🤝</span> Asignar
           </NavLink>

--- a/prioritask-frontend/src/components/TaskList.tsx
+++ b/prioritask-frontend/src/components/TaskList.tsx
@@ -163,10 +163,13 @@ const TaskList = () => {
                 Aplicar filtros
               </button>
             </div>
-          </div>
         </div>
+      </div>
+      <div className="d-flex justify-content-end mt-3">
+        <button className="btn btn-outline-secondary" onClick={() => navigate("/tasks/rewrite")}>🧠 Mejorar títulos</button>
+      </div>
 
-        <h2 className="mb-4">
+      <h2 className="mb-4">
           <span role="img" aria-label="Lista">
             📝
           </span>{" "}

--- a/prioritask-frontend/src/pages/GroupedTasks.tsx
+++ b/prioritask-frontend/src/pages/GroupedTasks.tsx
@@ -1,0 +1,52 @@
+import { useEffect, useState } from "react";
+import api from "../api";
+
+interface Group {
+  [groupName: string]: { id: string; titulo: string }[];
+}
+
+const GroupedTasks = () => {
+  const [groups, setGroups] = useState<Group>({});
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const fetchGroups = async () => {
+      try {
+        const res = await api.post("/tasks/ai/group", {});
+        setGroups(res.data.grupos);
+      } catch (err) {
+        console.error(err);
+        alert("Error al agrupar tareas");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchGroups();
+  }, []);
+
+  if (loading) return <p>Cargando grupos...</p>;
+
+  return (
+    <div className="container mt-4">
+      <h2>🧠 Tareas agrupadas</h2>
+      {Object.keys(groups).length === 0 ? (
+        <p>No se encontraron grupos.</p>
+      ) : (
+        Object.entries(groups).map(([name, tasks]) => (
+          <div className="card mb-3" key={name}>
+            <div className="card-header fw-bold">{name}</div>
+            <ul className="list-group list-group-flush">
+              {tasks.map((t) => (
+                <li key={t.id} className="list-group-item">
+                  {t.titulo}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
+export default GroupedTasks;

--- a/prioritask-frontend/src/pages/RewriteTitles.tsx
+++ b/prioritask-frontend/src/pages/RewriteTitles.tsx
@@ -1,0 +1,78 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import api from "../api";
+
+interface Suggestion {
+  id: string;
+  original: string;
+  reformulada: string;
+  motivo: string;
+}
+
+const RewriteTitles = () => {
+  const [suggestions, setSuggestions] = useState<Suggestion[]>([]);
+  const [loading, setLoading] = useState(true);
+  const navigate = useNavigate();
+
+  useEffect(() => {
+    const fetchSuggestions = async () => {
+      try {
+        const res = await api.post("/tasks/ai/rewrite", {});
+        setSuggestions(res.data);
+      } catch (err) {
+        console.error(err);
+        alert("Error al obtener sugerencias");
+      } finally {
+        setLoading(false);
+      }
+    };
+    fetchSuggestions();
+  }, []);
+
+  const acceptSuggestion = async (s: Suggestion) => {
+    try {
+      await api.patch(`/tasks/${s.id}`, { titulo: s.reformulada });
+      setSuggestions((prev) => prev.filter((item) => item.id !== s.id));
+    } catch (err) {
+      console.error(err);
+      alert("Error al actualizar tarea");
+    }
+  };
+
+  if (loading) return <p>Cargando sugerencias...</p>;
+
+  return (
+    <div className="container mt-4">
+      <h2>🧠 Mejorar títulos</h2>
+      <button className="btn btn-secondary mb-3" onClick={() => navigate("/tasks")}>Volver</button>
+      {suggestions.length === 0 ? (
+        <p>No hay sugerencias disponibles.</p>
+      ) : (
+        <table className="table">
+          <thead>
+            <tr>
+              <th>Tarea original</th>
+              <th>Título sugerido</th>
+              <th></th>
+            </tr>
+          </thead>
+          <tbody>
+            {suggestions.map((s) => (
+              <tr key={s.id}>
+                <td>{s.original}</td>
+                <td>{s.reformulada}</td>
+                <td>
+                  <button className="btn btn-primary btn-sm" onClick={() => acceptSuggestion(s)}>
+                    Aceptar
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+};
+
+export default RewriteTitles;


### PR DESCRIPTION
## Summary
- new `/tasks/grouped` page that uses the AI grouping endpoint
- new `/tasks/rewrite` page to show improved task titles
- navigation link "Agrupadas" added in Sidebar
- button on task list to open rewrite page
- routes wired in `App.tsx`

## Testing
- `pytest -q`
