### PR TITLE
Agregar funciones auxiliares para roomId y usarlas en las peticiones de tareas

### DIFF
--- a/prioritask-frontend/src/components/AssignTaskForm.tsx
+++ b/prioritask-frontend/src/components/AssignTaskForm.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from "react";
 import api from "../api";
 import Select from "react-select";
+import { getCurrentRoomId } from "../utils/room";
 
 interface Assignment {
   id: number;
@@ -28,7 +29,9 @@ const AssignTaskForm = () => {
             label: u.nombre || u.email,
           }))
         );
-        const tasksRes = await api.get("/tasks");
+        const tasksRes = await api.get("/tasks", {
+          params: { room_id: getCurrentRoomId() || undefined },
+        });
         setTasks(
           tasksRes.data.map((t: any) => ({ value: t.id, label: t.titulo }))
         );

--- a/prioritask-frontend/src/components/TaskForm.tsx
+++ b/prioritask-frontend/src/components/TaskForm.tsx
@@ -3,6 +3,7 @@ import api from "../api";
 import { useNavigate, useParams } from "react-router-dom";
 import Select from "react-select";
 import { TaskUpdateContext } from "../context/TaskUpdateContext";
+import { getCurrentRoomId } from "../utils/room";
 
 interface Tag {
   id: string;
@@ -123,6 +124,7 @@ const TaskForm = () => {
       peso,
       due_date: formatearFecha(dueDate),
       estado,
+      room_id: getCurrentRoomId() || undefined,
     };
 
     try {

--- a/prioritask-frontend/src/components/TaskList.tsx
+++ b/prioritask-frontend/src/components/TaskList.tsx
@@ -3,6 +3,7 @@ import api from "../api";
 import { useNavigate } from "react-router-dom";
 import debounce from "lodash/debounce";
 import { TaskUpdateContext } from "../context/TaskUpdateContext";
+import { getCurrentRoomId } from "../utils/room";
 
 interface Tarea {
   id: string;
@@ -34,6 +35,8 @@ const TaskList = () => {
       if (categoria) params.categoria = categoria;
       if (fechaLimite) params.due_date_max = fechaLimite;
       if (busqueda) params.search = busqueda;
+      const roomId = getCurrentRoomId();
+      if (roomId) params.room_id = roomId;
 
       const res = await api.get("/tasks", {
         params,

--- a/prioritask-frontend/src/pages/Dashboard.tsx
+++ b/prioritask-frontend/src/pages/Dashboard.tsx
@@ -4,11 +4,13 @@ import api from "../api";
 import { FaTasks, FaCheckCircle, FaExclamationTriangle } from "react-icons/fa";
 import styles from "./Dashboard.module.css";
 import { TaskUpdateContext } from "../context/TaskUpdateContext";
+import { RoomContext } from "../context/RoomContext";
 
 const Dashboard = () => {
   const [tareas, setTareas] = useState([]);
   const [rooms, setRooms] = useState<any[]>([]);
   const { version } = useContext(TaskUpdateContext);
+  const { setRoomId } = useContext(RoomContext);
 
   useEffect(() => {
     const fetchTareas = async () => {
@@ -87,7 +89,10 @@ const Dashboard = () => {
           <ul>
             {rooms.map((room: any) => (
               <li key={room.id}>
-                <Link to={`/rooms/${room.id}/tasks`}>
+                <Link
+                  to={`/rooms/${room.id}/tasks`}
+                  onClick={() => setRoomId(room.id)}
+                >
                   {room.nombre} ({room.count})
                 </Link>
               </li>

--- a/prioritask-frontend/src/pages/RoomTasks.tsx
+++ b/prioritask-frontend/src/pages/RoomTasks.tsx
@@ -1,11 +1,17 @@
-import { useEffect, useState } from "react";
+import { useEffect, useState, useContext } from "react";
 import { useParams } from "react-router-dom";
 import api from "../api";
+import { RoomContext } from "../context/RoomContext";
 
 const RoomTasks = () => {
   const { roomId } = useParams();
+  const { setRoomId } = useContext(RoomContext);
   const [tasks, setTasks] = useState<any[]>([]);
   const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setRoomId(roomId || null);
+  }, [roomId]);
 
   useEffect(() => {
     const fetch = async () => {

--- a/prioritask-frontend/src/utils/room.ts
+++ b/prioritask-frontend/src/utils/room.ts
@@ -1,0 +1,11 @@
+export const getCurrentRoomId = (): string | null => {
+  return localStorage.getItem("roomId");
+};
+
+export const saveCurrentRoomId = (id: string) => {
+  localStorage.setItem("roomId", id);
+};
+
+export const clearCurrentRoomId = () => {
+  localStorage.removeItem("roomId");
+};


### PR DESCRIPTION
## Resumen
- Persistir el `roomId` seleccionado en `localStorage` y exponer funciones auxiliares  
- Incluir el `roomId` al crear o listar tareas  
- Actualizar los enlaces de salas en el dashboard para establecer la sala actual  
- Mantener el contexto de sala en la página `RoomTasks`  

