### PR TITLE
Agregar verificación de creación de hogar en el Dashboard

### DIFF
--- a/prioritask-frontend/src/pages/CreateRoom.tsx
+++ b/prioritask-frontend/src/pages/CreateRoom.tsx
@@ -25,7 +25,7 @@ const CreateRoom = () => {
 
   return (
     <div className="container mt-4">
-      <h2>Crear Hogar</h2>
+      <h2>Crea tu hogar para comenzar</h2>
       {error && <div className="alert alert-danger">{error}</div>}
       <form onSubmit={handleSubmit}>
         <div className="mb-3">
@@ -33,12 +33,15 @@ const CreateRoom = () => {
           <input
             type="text"
             className="form-control"
+            placeholder="Mi Casa"
             value={name}
             onChange={(e) => setName(e.target.value)}
             required
           />
         </div>
-        <button type="submit" className="btn btn-primary">Crear</button>
+        <button type="submit" className="btn btn-primary" disabled={!name}>
+          Crear
+        </button>
       </form>
     </div>
   );

--- a/prioritask-frontend/src/pages/Dashboard.tsx
+++ b/prioritask-frontend/src/pages/Dashboard.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState, useContext } from "react";
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import api from "../api";
 import { FaTasks, FaCheckCircle, FaExclamationTriangle } from "react-icons/fa";
 import styles from "./Dashboard.module.css";
@@ -10,7 +10,8 @@ const Dashboard = () => {
   const [tareas, setTareas] = useState([]);
   const [rooms, setRooms] = useState<any[]>([]);
   const { version } = useContext(TaskUpdateContext);
-  const { setRoomId } = useContext(RoomContext);
+  const { roomId, setRoomId } = useContext(RoomContext);
+  const navigate = useNavigate();
 
   useEffect(() => {
     const fetchTareas = async () => {
@@ -21,6 +22,11 @@ const Dashboard = () => {
     const fetchRooms = async () => {
       try {
         const r = await api.get("/rooms");
+        if (r.data.length === 0) {
+          navigate("/rooms/create");
+          return;
+        }
+
         const list = await Promise.all(
           r.data.map(async (room: any) => {
             const tasksRes = await api.get(`/rooms/${room.id}/tasks`, { params: { limit: 100 } });
@@ -28,6 +34,10 @@ const Dashboard = () => {
           })
         );
         setRooms(list);
+
+        if (!roomId) {
+          setRoomId(list[0].id);
+        }
       } catch (err) {
         console.error(err);
       }


### PR DESCRIPTION
## Resumen
- Actualizar el texto de `CreateRoom` y desactivar el botón cuando no se proporciona un nombre  
- Redirigir desde el Dashboard a la creación de hogar cuando no existan salas, y almacenar el ID de la primera sala  