### PR TITLE
Añadir entrada de historial de borrado

### DIFF
--- a/app/api/v1/endpoints/tasks.py
+++ b/app/api/v1/endpoints/tasks.py
@@ -321,7 +321,15 @@ async def delete_task(
     if task.user_id != current_user.id:
         return ERROR_FORBIDDEN
 
+    task_id_to_delete = task.id
     await session.delete(task)
+
+    history = TaskHistory(
+        task_id=task_id_to_delete,
+        user_id=current_user.id,
+        action="DELETED",
+    )
+    session.add(history)
     await session.commit()
 
 class UpdateTaskStatus(BaseModel):

--- a/tests/tests_delete_task.py
+++ b/tests/tests_delete_task.py
@@ -75,3 +75,12 @@ async def test_delete_task_creates_history(async_client):
     )
 
     assert response.status_code == 204
+
+    history_resp = await async_client.get(
+        f"/api/v1/tasks/{task['id']}/history",
+        headers={"Authorization": f"Bearer {token}"}
+    )
+
+    assert history_resp.status_code == 200
+    actions = [h["action"] for h in history_resp.json()]
+    assert "DELETED" in actions


### PR DESCRIPTION
## Resumen
- registrar la eliminación de tareas en la tabla del historial y exponerla a través de la API
- probar que la eliminación de una tarea registra una acción 'ELIMINADA

