### PR TITLE
Eliminar importación sqlalchemy no utilizada

### DIFF
--- a/tests/test_tags.py
+++ b/tests/test_tags.py
@@ -2,7 +2,6 @@ from uuid import UUID
 
 import pytest
 from httpx import AsyncClient
-from sqlalchemy import select
 from sqlmodel import select, delete
 from sqlmodel.ext.asyncio.session import AsyncSession
 from app.models import Tag, TaskTag


### PR DESCRIPTION
## Resumen
- eliminar importación duplicada de pruebas.