### PR TITLE
Añadir enlace al historial en el panel de control

### DIFF
--- a/prioritask-frontend/src/pages/Dashboard.tsx
+++ b/prioritask-frontend/src/pages/Dashboard.tsx
@@ -54,6 +54,10 @@ const Dashboard = () => {
     };
 
     loadData();
+
+    return () => {
+      controller.abort();
+    };
   }, [version]);
 
   return (


### PR DESCRIPTION
## Resumen
- añadir estado de carga al `Dashboard
- cargar tareas y salas juntas
- mostrar el botón "Historial" una vez cargados los datos