### PR TITLE
Añadir migración para nuevas relaciones de tareas y salas

### DIFF
--- a/app/db/migrations/versions/6926083f0630_add_room_parent_and_task_room_fk.py
+++ b/app/db/migrations/versions/6926083f0630_add_room_parent_and_task_room_fk.py
@@ -19,9 +19,9 @@ depends_on: Union[str, Sequence[str], None] = None
 
 def upgrade() -> None:
     """Upgrade schema."""
-    op.add_column('room', sa.Column('parent_id', sa.Uuid(), nullable=True))
+    op.add_column('room', sa.Column('parent_id', sa.UUID(), nullable=True))
     op.create_foreign_key('room_parent_id_fkey', 'room', 'room', ['parent_id'], ['id'])
-    op.add_column('task', sa.Column('room_id', sa.Uuid(), nullable=False))
+    op.add_column('task', sa.Column('room_id', sa.UUID(), nullable=False))
     op.create_foreign_key('task_room_id_fkey', 'task', 'room', ['room_id'], ['id'])
 
 


### PR DESCRIPTION
## Resumen
- añadir revisión Alembic para incluir `room.parent_id` y `task.room_id
- crear claves foráneas para las dos nuevas columnas
- eliminar las restricciones y columnas en downgrade