### PR TITLE
Añadir esquemas de jerarquía de habitaciones

### DIFF
--- a/app/schemas/room.py
+++ b/app/schemas/room.py
@@ -1,6 +1,20 @@
 from pydantic import BaseModel, ConfigDict, Field
 from uuid import UUID
 
+
+class RoomBase(BaseModel):
+    nombre: str = Field(description="Nombre del hogar.",
+                         json_schema_extra={"example": "Mi Casa"})
+    parent_id: UUID | None = Field(
+        default=None,
+        description="ID del hogar padre",
+        json_schema_extra={"example": None},
+    )
+
+
+class RoomCreate(RoomBase):
+    pass
+
 class RoomRead(BaseModel):
     id: UUID = Field(description="Identificador único de la sala.", json_schema_extra={"example": "123e4567-e89b-12d3-a456-426614174000"})
     nombre: str = Field(description="Nombre de la sala.", json_schema_extra={"example": "Sala de reuniones"})


### PR DESCRIPTION
## Resumen
- permitir especificar jerarquías de habitaciones mediante `RoomBase` y `RoomCreate
- exponer `parent_id` al crear y listar habitaciones
