### PR TITLE
Arreglar el filtrado del historial por habitaciones

### DIFF
--- a/app/api/v1/endpoints/tasks.py
+++ b/app/api/v1/endpoints/tasks.py
@@ -259,15 +259,7 @@ async def list_task_history(
         room = await session.get(Room, room_id)
         if not room or room.owner_id != current_user.id:
             raise HTTPException(status_code=404, detail="Hogar no encontrado")
-        tag_result = await session.exec(
-            select(Tag).where(Tag.nombre == room.nombre, Tag.user_id == current_user.id)
-        )
-        tag = tag_result.one_or_none()
-        if not tag:
-            return []
-        filters.append(
-            Task.id.in_(select(TaskTag.task_id).where(TaskTag.tag_id == tag.id))
-        )
+        filters.append(Task.room_id == room_id)
     stmt = (
         select(TaskHistory)
         .join(Task, Task.id == TaskHistory.task_id)

--- a/tests/test_history_filters.py
+++ b/tests/test_history_filters.py
@@ -32,13 +32,11 @@ async def test_history_filter_by_room(async_client: AsyncClient):
 
     room_resp = await async_client.post("/api/v1/rooms", json={"nombre": "Casa"}, headers=headers)
     room_id = room_resp.json()["id"]
-    tag_resp = await async_client.post("/api/v1/tags", json={"nombre": "Casa"}, headers=headers)
-    tag_id = tag_resp.json()["id"]
+    other_room_resp = await async_client.post("/api/v1/rooms", json={"nombre": "Oficina"}, headers=headers)
+    other_room_id = other_room_resp.json()["id"]
 
-    t1 = await create_task(async_client, token, {"titulo": "Uno", "categoria": "OTRO"})
-    await create_task(async_client, token, {"titulo": "Dos", "categoria": "OTRO"})
-
-    await async_client.post(f"/api/v1/tags/tasks/{t1['id']}/tags", json={"tag_ids": [tag_id]}, headers=headers)
+    t1 = await create_task(async_client, token, {"titulo": "Uno", "categoria": "OTRO", "room_id": room_id})
+    await create_task(async_client, token, {"titulo": "Dos", "categoria": "OTRO", "room_id": other_room_id})
 
     resp = await async_client.get("/api/v1/tasks/history", params={"room_id": room_id}, headers=headers)
     assert resp.status_code == 200


### PR DESCRIPTION
## Resumen
- filtrar el punto final del historial con Task.room_id cuando se proporciona room_id
- actualizar las pruebas para comprobar la nueva lógica de filtrado.