### PR TITLE
Gestión de orígenes CORS mediante env

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,4 @@
 DATABASE_URL=sqlite+aiosqlite:///./prioritask.db
 JWT_SECRET_KEY=p7hRdZAzEHs+5p7IDgOu66BqHs2VSmpI6i1Jy6eNrrA=
 ACCESS_TOKEN_EXPIRE_MINUTES=60
+CORS_ORIGINS=http://localhost:5173

--- a/.env.example
+++ b/.env.example
@@ -3,3 +3,6 @@ DATABASE_URL=sqlite:///./prioritask.db
 
 # Seguridad
 JWT_SECRET_KEY=CHANGE_ME_SUPER_SECRET_KEY
+
+# CORS
+CORS_ORIGINS=http://localhost:5173

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -5,6 +5,7 @@ class Settings(BaseSettings):
     DATABASE_URL: str
     JWT_SECRET_KEY: str
     ACCESS_TOKEN_EXPIRE_MINUTES: int = 60
+    CORS_ORIGINS: str | None = "http://localhost:5173"
 
     model_config = ConfigDict(env_file=".env")
 

--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,8 @@
 from fastapi import FastAPI
 from app.api.v1 import api_router
 from fastapi.middleware.cors import CORSMiddleware
+from app.core.config import settings
+
 
 app = FastAPI(
     title="Prioritask API",
@@ -15,9 +17,13 @@ app = FastAPI(
         "url": "https://opensource.org/licenses/MIT"
     }
 )
+origins = [o.strip() for o in (settings.CORS_ORIGINS or "").split(",") if o.strip()]
+if not origins:
+    origins = ["http://localhost:5173"]
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["http://localhost:5173"],
+    allow_origins=origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Resumen
- permitir la configuración de orígenes CORS en `Settings
- usar configuración en `FastAPI` setup
- document `CORS_ORIGINS` in `.env.example`